### PR TITLE
fix: replacing importScripts with a dynamic import to fix error at run time

### DIFF
--- a/modules/worker-utils/src/lib/library-utils/library-utils.ts
+++ b/modules/worker-utils/src/lib/library-utils/library-utils.ts
@@ -83,7 +83,7 @@ async function loadLibraryFromFile(libraryUrl) {
     return node.requireFromFile && (await node.requireFromFile(libraryUrl));
   }
   if (isWorker) {
-    return importScripts(libraryUrl);
+    return import(libraryUrl);
   }
   // TODO - fix - should be more secure than string parsing since observes CORS
   // if (isBrowser) {


### PR DESCRIPTION
…e in Chrome

importScripts() has a problem because the specified urls are supposed to resolve relative to the entry worker script which we cannot know at build time